### PR TITLE
Call FocusManager removeView on ComponentImpl onRemovedFromStage

### DIFF
--- a/haxe/ui/backend/ComponentImpl.hx
+++ b/haxe/ui/backend/ComponentImpl.hx
@@ -58,6 +58,7 @@ class ComponentImpl extends ComponentBase {
         if (component.parentComponent == null && Screen.instance.rootComponents.indexOf(component) != -1) {
             Screen.instance.rootComponents.remove(component);
             Screen.instance._topLevelComponents.remove(component); // TODO: look into removing and using rootComponents only, order / ready() is important
+            FocusManager.instance.removeView(component);
         }
     }
     


### PR DESCRIPTION
Fixes issue where component wasn't being removed from FocusManager views when component was removed from stage.