### PR TITLE
Fix OpenFileDialogImpl.hx when compiling to Android 

### DIFF
--- a/haxe/ui/backend/OpenFileDialogImpl.hx
+++ b/haxe/ui/backend/OpenFileDialogImpl.hx
@@ -1,16 +1,15 @@
 package haxe.ui.backend;
 
 
-#if !js
+#if (!js && !android)
 import haxe.io.Bytes;
 import haxe.ui.containers.dialogs.Dialog.DialogButton;
 import haxe.ui.containers.dialogs.Dialogs.FileDialogExtensionInfo;
 import openfl.events.Event;
 import openfl.net.FileFilter;
 import openfl.net.FileReference;
-#end
-
 import openfl.net.FileReferenceList;
+#end
 
 import haxe.ui.containers.dialogs.Dialogs.SelectedFileInfo;
 
@@ -42,6 +41,12 @@ class OpenFileDialogImpl extends OpenFileDialogBase {
         }
     }
     
+    #elseif android
+
+    public override function show() {
+        dialogCancelled();
+    }
+
     #else
     
     private var _fr:FileReferenceList = null;

--- a/haxe/ui/backend/OpenFileDialogImpl.hx
+++ b/haxe/ui/backend/OpenFileDialogImpl.hx
@@ -1,7 +1,7 @@
 package haxe.ui.backend;
 
 
-#if (!js && !android)
+#if (!js && !mobile)
 import haxe.io.Bytes;
 import haxe.ui.containers.dialogs.Dialog.DialogButton;
 import haxe.ui.containers.dialogs.Dialogs.FileDialogExtensionInfo;
@@ -41,7 +41,7 @@ class OpenFileDialogImpl extends OpenFileDialogBase {
         }
     }
     
-    #elseif android
+    #elseif mobile
 
     public override function show() {
         dialogCancelled();

--- a/haxe/ui/backend/OpenFileDialogImpl.hx
+++ b/haxe/ui/backend/OpenFileDialogImpl.hx
@@ -8,8 +8,9 @@ import haxe.ui.containers.dialogs.Dialogs.FileDialogExtensionInfo;
 import openfl.events.Event;
 import openfl.net.FileFilter;
 import openfl.net.FileReference;
-import openfl.net.FileReferenceList;
 #end
+
+import openfl.net.FileReferenceList;
 
 import haxe.ui.containers.dialogs.Dialogs.SelectedFileInfo;
 


### PR DESCRIPTION
It seems that with the current changes when trying to compile for Android (and probably iOS), `OpenFileDialogImpl.hx` fails, saying that it cannot find `FileReferenceList`, so I have made some changes to fix it heh